### PR TITLE
install docker-py with pip module in playbook

### DIFF
--- a/05 - Using Ansible with Cloud Services and Containers/02 - Docker support with Ansible/02/docker_playbook.yml
+++ b/05 - Using Ansible with Cloud Services and Containers/02 - Docker support with Ansible/02/docker_playbook.yml
@@ -11,6 +11,10 @@
   # Task: the list of tasks that will be executed within the play, this section
   # can also be used for pre and post tasks
   tasks:
+    - name: install docker-py with pip
+      pip:
+        name: docker-py
+
     - name: Pull rastasheep's ubuntu-sshd image
       docker_image:
         name: rastasheep/ubuntu-sshd


### PR DESCRIPTION
docker-py needs to be installed in docker-server.  Instead of remote installation, this demonstrates an alternative approach, i.e. using pip module in the Ansible playbook.